### PR TITLE
Use new closure stage syntax to avoid issues with parallel execution

### DIFF
--- a/src/com/ibm/oip/jenkins/BuildContext.groovy
+++ b/src/com/ibm/oip/jenkins/BuildContext.groovy
@@ -64,10 +64,11 @@ class BuildContext implements Serializable {
         this.pullRequestCommitId = retrieveLastCommitOfPullRequest(scriptEngine);
     }
 
-    def changeStage(stage) {
+    def changeStage(String stage, Closure stageClosure) {
         this.stage = stage;
-        this.scriptEngine.env.STAGE = stage;
-        this.scriptEngine.stage stage;
+        this.scriptEngine.env.STAGE = stage
+        stageClosure.setDelegate(this.scriptEngine.stage)
+        this.scriptEngine.stage(stage, stageClosure)
     }
 
     private static String retrieveCommitId(scriptEngine) {

--- a/src/com/ibm/oip/jenkins/steps/Checkout.groovy
+++ b/src/com/ibm/oip/jenkins/steps/Checkout.groovy
@@ -4,13 +4,14 @@ import com.ibm.oip.jenkins.BuildContext;
 
 class Checkout extends Step {
     void doStep(BuildContext buildContext) {
-        buildContext.changeStage("Checkout");
-        buildContext.getScriptEngine().checkout([$class           : 'GitSCM',
-                                                 branches         : [[name: "refs/heads/enhancement/kubernetes"]],
-                                                 userRemoteConfigs: [[credentialsId: 'AOK-FAMI-github', url: "https://github.gcloud.eu-de.bluemix.net/${env.GROUP}/${env.SERVICE}.git"]],
-                                                 extensions       : [[$class: 'LocalBranch', localBranch: "enhancement/kubernetes"]]]) {
+        buildContext.changeStage("Checkout") {
+            checkout([$class           : 'GitSCM',
+                      branches         : [[name: "refs/heads/enhancement/kubernetes"]],
+                      userRemoteConfigs: [[credentialsId: 'AOK-FAMI-github', url: "https://github.gcloud.eu-de.bluemix.net/${env.GROUP}/${env.SERVICE}.git"]],
+                      extensions       : [[$class: 'LocalBranch', localBranch: "enhancement/kubernetes"]]]) {
 
+            }
         }
-        buildContext.addGitProperties();
+        buildContext.addGitProperties()
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/SCMCheckout.groovy
+++ b/src/com/ibm/oip/jenkins/steps/SCMCheckout.groovy
@@ -3,15 +3,15 @@ package com.ibm.oip.jenkins.steps;
 import com.ibm.oip.jenkins.BuildContext;
 
 class SCMCheckout extends Step {
-    public void doStep(BuildContext buildContext) {
-        buildContext.changeStage("Checkout");
-        buildContext.getScriptEngine().checkout([
-                $class: 'GitSCM',
-                branches: buildContext.getScriptEngine().scm.branches,
-                extensions: [[$class: 'LocalBranch', localBranch: buildContext.branch], [$class: 'CloneOption', depth: 0, noTags: false, reference: '', shallow: false]],
-                userRemoteConfigs: buildContext.getScriptEngine().scm.userRemoteConfigs
-        ])
-
-        buildContext.addGitProperties();
+    void doStep(BuildContext buildContext) {
+        buildContext.changeStage("Checkout") {
+            checkout([
+                    $class           : 'GitSCM',
+                    branches         : buildContext.getScriptEngine().scm.branches,
+                    extensions       : [[$class: 'LocalBranch', localBranch: buildContext.branch], [$class: 'CloneOption', depth: 0, noTags: false, reference: '', shallow: false]],
+                    userRemoteConfigs: buildContext.getScriptEngine().scm.userRemoteConfigs
+            ])
+        }
+        buildContext.addGitProperties()
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/deployment/TriggerDeployment.groovy
+++ b/src/com/ibm/oip/jenkins/steps/deployment/TriggerDeployment.groovy
@@ -7,22 +7,24 @@ import com.ibm.oip.jenkins.steps.Step;
 class TriggerDeployment extends Step {
     def targetEnvironment;
 
-    TriggerDeployment(String targetEnvironment){
+    TriggerDeployment(String targetEnvironment) {
         this.targetEnvironment = targetEnvironment
     }
 
     BuildContext buildContext;
-    void doStep(BuildContext buildContext) {
-        buildContext.changeStage("Deployment to ${targetEnvironment}")
-        buildContext.getScriptEngine().sh "echo ${buildContext.version}"
 
-        def deployment = buildContext.getScriptEngine().build job: buildContext.getScriptEngine().env.DEPLOYMENT_JOB_NAME, parameters: [[$class: 'StringParameterValue', name: 'group', value: buildContext.group],
-                                                    [$class: 'StringParameterValue', name: 'service', value: buildContext.project],
-                                                    [$class: 'StringParameterValue', name: 'version', value: buildContext.version],
-                                                    [$class: 'StringParameterValue', name: 'environment', value: targetEnvironment]],
-                                        wait: true, propagate: false, quietPeriod: 0
-        if (deployment.result == 'FAILURE'){
-            throw new DeploymentTriggerException("Deployment job to target environment ${targetEnvironment} failed!")
+    void doStep(BuildContext buildContext) {
+        buildContext.changeStage("Deployment to ${targetEnvironment}") {
+            sh "echo ${buildContext.version}"
+            def deployment = build job: buildContext.getScriptEngine().env.DEPLOYMENT_JOB_NAME,
+                    parameters: [[$class: 'StringParameterValue', name: 'group', value: buildContext.group],
+                                 [$class: 'StringParameterValue', name: 'service', value: buildContext.project],
+                                 [$class: 'StringParameterValue', name: 'version', value: buildContext.version],
+                                 [$class: 'StringParameterValue', name: 'environment', value: targetEnvironment]],
+                    wait: true, propagate: false, quietPeriod: 0
+            if (deployment.result == 'FAILURE') {
+                throw new DeploymentTriggerException("Deployment job to target environment ${targetEnvironment} failed!")
+            }
         }
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/deployment/cloudfoundry/CloudFoundryDeployment.groovy
+++ b/src/com/ibm/oip/jenkins/steps/deployment/cloudfoundry/CloudFoundryDeployment.groovy
@@ -12,23 +12,24 @@ class CloudFoundryDeployment extends Step {
 
     void doStep(BuildContext buildContext) {
         def version = buildContext.version.substring(2)
-        buildContext.changeStage("Deploy to CF")
-        def secrets = [
-                [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/environments/dev/deployment/bluemix", secretValues: [
-                        [$class: 'VaultSecretValue', envVar: 'CLOUD_FOUNDRY_USERNAME', vaultKey: 'username'],
-                        [$class: 'VaultSecretValue', envVar: 'CLOUD_FOUNDRY_PASSWORD', vaultKey: 'password']]],
-                [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/environments/tools/nexus", secretValues: [
-                        [$class: 'VaultSecretValue', envVar: 'NEXUS_USERNAME', vaultKey: 'username'],
-                        [$class: 'VaultSecretValue', envVar: 'NEXUS_PASSWORD', vaultKey: 'password']]]
-        ]
-        buildContext.getScriptEngine().wrap([$class: 'VaultBuildWrapper', vaultSecrets: secrets]) {
-            // fetch distZip from Nexus
-            buildContext.getScriptEngine().sh "wget --user ${buildContext.getScriptEngine().env.NEXUS_USERNAME} --password ${buildContext.getScriptEngine().env.NEXUS_PASSWORD} https://nexus.open-insurance-platform.com/repository/tk-releases/com/ibm/ega/${buildContext.project}/${version}/${buildContext.project}-${version}.zip -O deployment.zip"
-            // fetch manifest.yml from Nexus
-            buildContext.getScriptEngine().sh "wget --user ${buildContext.getScriptEngine().env.NEXUS_USERNAME} --password ${buildContext.getScriptEngine().env.NEXUS_PASSWORD} https://nexus.open-insurance-platform.com/repository/tk-releases/com/ibm/ega/${buildContext.project}/${version}/${buildContext.project}-${version}-cloudfoundry-${targetEnvironment}.yml -O deployment.yml"
-            // use CF and override the file
-            buildContext.getScriptEngine().sh "cf login -u ${buildContext.getScriptEngine().env.CLOUD_FOUNDRY_USERNAME} -p ${buildContext.getScriptEngine().env.CLOUD_FOUNDRY_PASSWORD} -a https://api.gcloud.eu-de.bluemix.net"
-            buildContext.getScriptEngine().sh "cf push -f deployment.yml -p deployment.zip"
+        buildContext.changeStage("Deploy to CF") {
+            def secrets = [
+                    [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/environments/dev/deployment/bluemix", secretValues: [
+                            [$class: 'VaultSecretValue', envVar: 'CLOUD_FOUNDRY_USERNAME', vaultKey: 'username'],
+                            [$class: 'VaultSecretValue', envVar: 'CLOUD_FOUNDRY_PASSWORD', vaultKey: 'password']]],
+                    [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/environments/tools/nexus", secretValues: [
+                            [$class: 'VaultSecretValue', envVar: 'NEXUS_USERNAME', vaultKey: 'username'],
+                            [$class: 'VaultSecretValue', envVar: 'NEXUS_PASSWORD', vaultKey: 'password']]]
+            ]
+            wrap([$class: 'VaultBuildWrapper', vaultSecrets: secrets]) {
+                // fetch distZip from Nexus
+                sh "wget --user ${env.NEXUS_USERNAME} --password ${env.NEXUS_PASSWORD} https://nexus.open-insurance-platform.com/repository/tk-releases/com/ibm/ega/${buildContext.project}/${version}/${buildContext.project}-${version}.zip -O deployment.zip"
+                // fetch manifest.yml from Nexus
+                sh "wget --user ${env.NEXUS_USERNAME} --password ${env.NEXUS_PASSWORD} https://nexus.open-insurance-platform.com/repository/tk-releases/com/ibm/ega/${buildContext.project}/${version}/${buildContext.project}-${version}-cloudfoundry-${targetEnvironment}.yml -O deployment.yml"
+                // use CF and override the file
+                sh "cf login -u ${buildContext.getScriptEngine().env.CLOUD_FOUNDRY_USERNAME} -p ${env.CLOUD_FOUNDRY_PASSWORD} -a https://api.gcloud.eu-de.bluemix.net"
+                sh "cf push -f deployment.yml -p deployment.zip"
+            }
         }
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/deployment/docker/IBMContainerDeployment.groovy
+++ b/src/com/ibm/oip/jenkins/steps/deployment/docker/IBMContainerDeployment.groovy
@@ -10,24 +10,25 @@ class IBMContainerDeployment extends Step {
         this.targetEnvironment = targetEnvironment
     }
 
-    public void doStep(BuildContext buildContext) {
-        buildContext.changeStage("Deploy to IBM Containers")
-        def secrets = [
-                [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/environments/dev/deployment/bluemix", secretValues: [
-                        [$class: 'VaultSecretValue', envVar: 'CLOUD_FOUNDRY_USERNAME', vaultKey: 'username'],
-                        [$class: 'VaultSecretValue', envVar: 'CLOUD_FOUNDRY_PASSWORD', vaultKey: 'password']]]
-        ]
-        buildContext.getScriptEngine().wrap([$class: 'VaultBuildWrapper', vaultSecrets: secrets]) {
-            buildContext.getScriptEngine().sh "cf login -o GHealthDev -s Dev -u ${buildContext.getScriptEngine().env.CLOUD_FOUNDRY_USERNAME} -p ${buildContext.getScriptEngine().env.CLOUD_FOUNDRY_PASSWORD} -a https://api.gcloud.eu-de.bluemix.net"
-            buildContext.getScriptEngine().sh "cf ic login"
+    void doStep(BuildContext buildContext) {
+        buildContext.changeStage("Deploy to IBM Containers") {
+            def secrets = [
+                    [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/environments/dev/deployment/bluemix", secretValues: [
+                            [$class: 'VaultSecretValue', envVar: 'CLOUD_FOUNDRY_USERNAME', vaultKey: 'username'],
+                            [$class: 'VaultSecretValue', envVar: 'CLOUD_FOUNDRY_PASSWORD', vaultKey: 'password']]]
+            ]
+            wrap([$class: 'VaultBuildWrapper', vaultSecrets: secrets]) {
+                sh "cf login -o GHealthDev -s Dev -u ${env.CLOUD_FOUNDRY_USERNAME} -p ${env.CLOUD_FOUNDRY_PASSWORD} -a https://api.gcloud.eu-de.bluemix.net"
+                buildContext.getScriptEngine().sh "cf ic login"
 
-            def oldGroupId = buildContext.getScriptEngine().sh(script: "cf ic group list | awk '\$2 ~ /${buildContext.getProject()}/ {print \$1}'", returnStdout: true);
-            buildContext.getScriptEngine().sh "cf ic group create --name ${buildContext.getProject()}-${buildContext.getVersion()} -p 8080 --min 2 --auto \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${buildContext.getProject()}:${buildContext.getVersion()}";
-            buildContext.getScriptEngine().sh "cf ic route map -n ${buildContext.getProject()} -d gcloud.eu-de.mybluemix.net ${buildContext.getProject()}-${buildContext.getVersion()}";
-            buildContext.getScriptEngine().sh "sleep 120"
+                def oldGroupId = sh(script: "cf ic group list | awk '\$2 ~ /${buildContext.getProject()}/ {print \$1}'", returnStdout: true);
+                buildContext.getScriptEngine().sh "cf ic group create --name ${buildContext.getProject()}-${buildContext.getVersion()} -p 8080 --min 2 --auto \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${buildContext.getProject()}:${buildContext.getVersion()}";
+                sh "cf ic route map -n ${buildContext.getProject()} -d gcloud.eu-de.mybluemix.net ${buildContext.getProject()}-${buildContext.getVersion()}";
+                sh "sleep 120"
 
-            if(oldGroupId) {
-                buildContext.getScriptEngine().sh "cf ic group rm ${oldGroupId}"
+                if (oldGroupId) {
+                    sh "cf ic group rm ${oldGroupId}"
+                }
             }
         }
     }

--- a/src/com/ibm/oip/jenkins/steps/docker/CheckDockerBuild.groovy
+++ b/src/com/ibm/oip/jenkins/steps/docker/CheckDockerBuild.groovy
@@ -8,8 +8,9 @@ class CheckDockerBuild extends Step {
 
     void doStep(BuildContext buildContext) {
         this.buildContext = buildContext
-        buildContext.changeStage('Check: Container-Build');
-        buildContext.getScriptEngine().sh "docker build -t ${buildContext.getCommitId()} ."
-        buildContext.getScriptEngine().sh "docker rmi ${buildContext.getCommitId()}"
+        buildContext.changeStage('Check: Container-Build') {
+            sh "docker build -t ${buildContext.getCommitId()} ."
+            sh "docker rmi ${buildContext.getCommitId()}"
+        }
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/docker/CreatePushContainer.groovy
+++ b/src/com/ibm/oip/jenkins/steps/docker/CreatePushContainer.groovy
@@ -5,24 +5,25 @@ import com.ibm.oip.jenkins.steps.Step
 
 class CreatePushContainer extends Step {
     void doStep(BuildContext buildContext) {
-        buildContext.changeStage('Build Container')
-        def project = buildContext.getProject()
-        def version = buildContext.getVersion()
-        buildContext.getScriptEngine().sh "docker build -t \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:${version} -t \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:latest .";
+        buildContext.changeStage('Build Container') {
+            def project = buildContext.getProject()
+            def version = buildContext.getVersion()
+            sh "docker build -t \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:${version} -t \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:latest .";
 
-        def secrets = [
-                [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/tools/docker-registry", secretValues: [
-                        [$class: 'VaultSecretValue', envVar: 'USERNAME', vaultKey: 'username'],
-                        [$class: 'VaultSecretValue', envVar: 'PASSWORD', vaultKey: 'password']]]
-        ]
-        buildContext.getScriptEngine().wrap([$class: 'VaultBuildWrapper', vaultSecrets: secrets]) {
-            buildContext.getScriptEngine().sh "docker login -u \$USERNAME -p \$PASSWORD \$DOCKER_REGISTRY_URL"
+            def secrets = [
+                    [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/tools/docker-registry", secretValues: [
+                            [$class: 'VaultSecretValue', envVar: 'USERNAME', vaultKey: 'username'],
+                            [$class: 'VaultSecretValue', envVar: 'PASSWORD', vaultKey: 'password']]]
+            ]
+            wrap([$class: 'VaultBuildWrapper', vaultSecrets: secrets]) {
+                sh "docker login -u \$USERNAME -p \$PASSWORD \$DOCKER_REGISTRY_URL"
+            }
+            sh "docker push \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:${version}"
+            sh "docker push \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:latest"
+
+            // delete the images from jenkins
+            sh "docker rmi \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:${version}"
+            sh "docker rmi \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:latest"
         }
-        buildContext.getScriptEngine().sh "docker push \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:${version}"
-        buildContext.getScriptEngine().sh "docker push \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:latest"
-
-        // delete the images from jenkins
-        buildContext.getScriptEngine().sh "docker rmi \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:${version}"
-        buildContext.getScriptEngine().sh "docker rmi \$DOCKER_REGISTRY_URL/\$DOCKER_REGISTRY_NAMESPACE/${project}:latest"
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/java/gradle/Assemble.groovy
+++ b/src/com/ibm/oip/jenkins/steps/java/gradle/Assemble.groovy
@@ -1,12 +1,12 @@
-package com.ibm.oip.jenkins.steps.java.gradle;
+package com.ibm.oip.jenkins.steps.java.gradle
 
 import com.ibm.oip.jenkins.BuildContext
-import com.ibm.oip.jenkins.steps.Step;
 
 class Assemble extends AbstractGradleStep {
 
     void doStep(BuildContext buildContext) {
-        buildContext.changeStage('Assemble');
-        doGradleStep(buildContext, "clean assemble")
+        buildContext.changeStage('Assemble') {
+            doGradleStep(buildContext, "clean assemble")
+        }
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/java/gradle/InstallDist.groovy
+++ b/src/com/ibm/oip/jenkins/steps/java/gradle/InstallDist.groovy
@@ -4,7 +4,8 @@ import com.ibm.oip.jenkins.BuildContext
 
 class InstallDist extends AbstractGradleStep {
     void doStep(BuildContext buildContext) {
-        buildContext.changeStage('Assemble (Distribution)');
-        doGradleStep(buildContext, "clean installDist")
+        buildContext.changeStage('Assemble (Distribution)') {
+            doGradleStep(buildContext, "clean installDist")
+        }
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/java/gradle/IntegrationTest.groovy
+++ b/src/com/ibm/oip/jenkins/steps/java/gradle/IntegrationTest.groovy
@@ -1,20 +1,18 @@
-package com.ibm.oip.jenkins.steps.java.gradle;
+package com.ibm.oip.jenkins.steps.java.gradle
 
 import com.ibm.oip.jenkins.BuildContext
-import com.ibm.oip.jenkins.steps.Step;
 
 class IntegrationTest extends AbstractGradleStep {
 
     void doStep(BuildContext buildContext) {
-        buildContext.changeStage('Integration test');
-        def reportDir = 'build/reports/tests/integrationTest';
-        try {
-            doGradleStep(buildContext, "-x test integrationTest")
-        } finally {
-            buildContext.getScriptEngine().publishHTML(target: [allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: "${reportDir}", reportFiles: 'index.html', reportName: 'Integrations-Test Report'])
-            buildContext.getScriptEngine().step([$class: 'JUnitResultArchiver', testResults: "**/build/test-results/integrationTest/*.xml"])
-
+        buildContext.changeStage('Integration test') {
+            def reportDir = 'build/reports/tests/integrationTest'
+            try {
+                doGradleStep(buildContext, "-x test integrationTest")
+            } finally {
+                publishHTML(target: [allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: "${reportDir}", reportFiles: 'index.html', reportName: 'Integrations-Test Report'])
+                step([$class: 'JUnitResultArchiver', testResults: "**/build/test-results/integrationTest/*.xml"])
+            }
         }
-
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/java/gradle/PublishArtifacts.groovy
+++ b/src/com/ibm/oip/jenkins/steps/java/gradle/PublishArtifacts.groovy
@@ -4,9 +4,10 @@ import com.ibm.oip.jenkins.BuildContext
 
 class PublishArtifacts extends AbstractGradleStep {
     @Override
-    public void doStep(BuildContext buildContext) {
-        buildContext.changeStage("Publish artifacts")
-        doGradleStep(buildContext, "publish");
+    void doStep(BuildContext buildContext) {
+        buildContext.changeStage("Publish artifacts") {
+            doGradleStep(buildContext, "publish")
+        }
     }
 }
 

--- a/src/com/ibm/oip/jenkins/steps/java/gradle/ShadowAssemble.groovy
+++ b/src/com/ibm/oip/jenkins/steps/java/gradle/ShadowAssemble.groovy
@@ -1,12 +1,11 @@
-package com.ibm.oip.jenkins.steps.java.gradle;
+package com.ibm.oip.jenkins.steps.java.gradle
 
 import com.ibm.oip.jenkins.BuildContext
-import com.ibm.oip.jenkins.steps.Step;
 
 class ShadowAssemble extends AbstractGradleStep {
-
     void doStep(BuildContext buildContext) {
-        buildContext.changeStage('Assemble');
-        doGradleStep(buildContext, "clean shadowJar")
+        buildContext.changeStage('Assemble') {
+            doGradleStep(buildContext, "clean shadowJar")
+        }
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/java/gradle/UnitTest.groovy
+++ b/src/com/ibm/oip/jenkins/steps/java/gradle/UnitTest.groovy
@@ -1,28 +1,24 @@
-package com.ibm.oip.jenkins.steps.java.gradle;
+package com.ibm.oip.jenkins.steps.java.gradle
 
 import com.ibm.oip.jenkins.BuildContext
-import com.ibm.oip.jenkins.steps.Step;
 
 class UnitTest extends AbstractGradleStep {
     private BuildContext buildContext;
 
     void doStep(BuildContext buildContext) {
         this.buildContext = buildContext;
-        buildContext.changeStage('Unit test');
-        try {
-            doGradleStep(buildContext, "test")
-        } finally {
-            publishTestResults();
+        buildContext.changeStage('Unit test') {
+            try {
+                doGradleStep(buildContext, "test")
+            } finally {
+                def reportDir = 'build/reports/tests/test';
+                if (!fileExists("${reportDir}")) {
+                    println "${reportDir} does not exist, not publishing anything."
+                    return
+                }
+                publishHTML(target: [allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: "${reportDir}", reportFiles: 'index.html', reportName: 'Unit-Test Report'])
+                step([$class: 'JUnitResultArchiver', testResults: "**/build/test-results/**/*.xml"])
+            }
         }
-    }
-
-    private void publishTestResults() {
-        def reportDir = 'build/reports/tests/test';
-        if (!buildContext.getScriptEngine().fileExists("${reportDir}") ){
-            println "${reportDir} does not exist, not publishing anything."
-            return
-        }
-        buildContext.getScriptEngine().publishHTML(target : [allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: "${reportDir}", reportFiles: 'index.html', reportName: 'Unit-Test Report'])
-        buildContext.getScriptEngine().step([$class: 'JUnitResultArchiver', testResults: "**/build/test-results/**/*.xml"])
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/java/gradle/analysis/StaticAnalysis.groovy
+++ b/src/com/ibm/oip/jenkins/steps/java/gradle/analysis/StaticAnalysis.groovy
@@ -4,26 +4,26 @@ import com.ibm.oip.jenkins.BuildContext
 import com.ibm.oip.jenkins.steps.java.gradle.AbstractGradleStep
 
 class StaticAnalysis extends AbstractGradleStep {
-    def skip;
+    def skip
 
-    public StaticAnalysis(def skip) {
-        this.skip = skip;
+    StaticAnalysis(def skip) {
+        this.skip = skip
     }
 
     void doStep(BuildContext buildContext) {
-        buildContext.changeStage('Static analysis');
-
-        def secrets = [
-                [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/tools/sonarqube", secretValues: [
-                        [$class: 'VaultSecretValue', envVar: 'SONARQUBE_TOKEN', vaultKey: 'api_token']]]
-        ]
-        buildContext.getScriptEngine().wrap([$class: 'VaultBuildWrapper', vaultSecrets: secrets]) {
-            doGradleStep(buildContext, "sonarqube " +
-                    "-Dsonar.buildbreaker.skip=$skip " +
-                    "-Dsonar.host.url=\$SONARQUBE_URL " +
-                    "-Dsonar.login='${buildContext.getScriptEngine().env.SONARQUBE_TOKEN}' " +
-                    "-Dsonar.jacoco.itReportPath=build/jacoco/integrationTest.exec -Dsonar.jacoco.reportPath=build/jacoco/test.exec");
-            // The last line should acutally not be needed since SQ 6.2 - but without it does not recognize the coverage
+        buildContext.changeStage('Static analysis') {
+            def secrets = [
+                    [$class: 'VaultSecret', path: "secret/${buildContext.getGroup()}/tools/sonarqube", secretValues: [
+                            [$class: 'VaultSecretValue', envVar: 'SONARQUBE_TOKEN', vaultKey: 'api_token']]]
+            ]
+            wrap([$class: 'VaultBuildWrapper', vaultSecrets: secrets]) {
+                doGradleStep(buildContext, "sonarqube " +
+                        "-Dsonar.buildbreaker.skip=$skip " +
+                        "-Dsonar.host.url=\$SONARQUBE_URL " +
+                        "-Dsonar.login='${env.SONARQUBE_TOKEN}' " +
+                        "-Dsonar.jacoco.itReportPath=build/jacoco/integrationTest.exec -Dsonar.jacoco.reportPath=build/jacoco/test.exec");
+                // The last line should acutally not be needed since SQ 6.2 - but without it does not recognize the coverage
+            }
         }
     }
 }

--- a/src/com/ibm/oip/jenkins/steps/java/gradle/release/FinishRelease.groovy
+++ b/src/com/ibm/oip/jenkins/steps/java/gradle/release/FinishRelease.groovy
@@ -5,7 +5,8 @@ import com.ibm.oip.jenkins.steps.java.gradle.AbstractGradleStep
 
 class FinishRelease extends AbstractGradleStep {
     void doStep(BuildContext buildContext) {
-        buildContext.changeStage('Publish release');
-        buildContext.getScriptEngine().sh ("git push --tags");
+        buildContext.changeStage('Publish release') {
+            sh("git push --tags")
+        }
     }
 }


### PR DESCRIPTION
The old syntax `scriptEngine.stage = stage` is incompatible with parallel execution. Instead, a closure must be passed that encapsulates all steps of a specific stage.

For this reason, `BuildContext`s `changeStage()` method changed and now must be called like this:

```groovy
buildContext.changeStage("some stage name") {
    // scriptEngine can be directly accessed here, no need to do
    // "buildContext.scriptEngine().sh", a simple "sh" is enough
}
```

I need to adapt the Android library for this change as well. Note that I haven't tested the other Step implementations, I merely patched it to match the new signature. If unsure, we can leave this in a separate branch and reference it only for specific builds (and not globally).